### PR TITLE
Add cleanup traps and type-checks for binaries

### DIFF
--- a/config.example
+++ b/config.example
@@ -2,7 +2,9 @@
 # Config file for jellyshot
 
 
-SERVER=server.domain
+SERVER='server.domain'
 SERVER_PATH=''
+# Becomes: https://server.doman/tmp/<name>
+SUFFIX='tmp'
 # SSH user
-USER=user
+USER='user'

--- a/jellyshot
+++ b/jellyshot
@@ -24,7 +24,6 @@ else
 fi
 
 ANIMALS=(Aardvark Albatross Alligator Alpaca Ant Anteater Antelope Ape Armadillo Baboon Badger Barracuda Bat Bear Beaver Bee Bison Boar Buffalo Galago Butterfly Camel Caribou Cat Caterpillar Cattle Chamois Cheetah Chicken Chimpanzee Chinchilla Chough Clam Cobra Cockroach Cod Cormorant Coyote Crab Crane Crocodile Crow Curlew Deer Dinosaur Dog Dogfish Dolphin Donkey Dotterel Dove Dragonfly Duck Dugong Dunlin Eagle Echidna Eel Eland Elephant Elephant seal Elk Emu Falcon Ferret Finch Fish Flamingo Fly Fox Frog Gaur Gazelle Gerbil Giant Panda Giraffe Gnat Gnu Goat Goose Goldfinch Goldfish Gorilla Goshawk Grasshopper Grouse Guanaco Guinea fowl Guinea pig Gull Hamster Hare Hawk Hedgehog Heron Herring Hippopotamus Hornet Horse Human Hummingbird Hyena Jackal Jaguar Jay Jay, Blue Jellyfish Kangaroo Koala Komodo dragon Kouprey Kudu Lapwing Lark Lemur Leopard Lion Llama Lobster Locust Loris Louse Lyrebird Magpie Mallard Manatee Marten Meerkat Mink Mole Monkey Moose Mouse Mosquito Mule Narwhal Newt Nightingale Octopus Okapi Opossum Oryx Ostrich Otter Owl Ox Oyster Panther Parrot Partridge Peafowl Pelican Penguin Pheasant Pig Pigeon Pony Porcupine Porpoise Prairie Dog Quail Quelea Rabbit Raccoon Rail Ram Rat Raven Red deer Red panda Reindeer Rhinoceros Rook Ruff Salamander Salmon Sandpiper Sardine Scorpion Sea lion Sea Urchin Seahorse Seal Shark Sheep Shrew Shrimp Skunk Snail Snake Spider Squid Squirrel Starling Stingray Stinkbug Stork Swallow Swan Tapir Tarsier Termite Tiger Toad Trout Turkey Turtle Vicuña Viper Vulture Wallaby Walrus Wasp Water buffalo Weasel Whale Wolf Wolverine Wombat Woodcock Woodpecker Worm Wren Yak Zebra)
-
 COLORS=(Red Blue Green Cyan Blue Purple Yellow Lime Magenta Green Orange Brown Maroon Black Silver White)
 VOWELS=(Amazing Gigantic Enormous Huge Broad Ridiculous Shallow Silent Soft Fluffy Dusty Miniature Chucklesome Absurd Hilarious Droll Amusing Silly Hysterical Humorous Laughable Astounding Astonishing Stunning Bewildering Shocking Startling Breathtaking Disconcerting Fierce Evil Frightened Foolish Creepy Confused Arrogant Ashamed Angry Awful Cheerful Witty Proud Jolly Kind Gentle)
 
@@ -35,19 +34,37 @@ animal="$(rand_element "ANIMALS[@]")"
 name="${vowel}${colors}${animal}.png"
 file="/tmp/$name"
 
-import "$file"
-if [[ -f /usr/bin/optipng ]]; then
+if type import &>/dev/null; then
+  import "$file"
+else
+  printf "%s\n" '"import" not found in $PATH'
+  exit 1
+fi
+
+if type optipng &>/dev/null; then
   optipng "$file" &>/dev/null
 fi
 
-if [[ -z $SERVER_PATH ]]; then
-  scp $file $SERVER:/home/$USER/public_html/dump/
-  url="https://$SERVER/~$USER/dump/$name"
+# Add single / prefix if SUFFIX is set
+case "$SUFFIX" in
+  (/*) SUFFIX="/${SUFFIX//\/}" ;;
+  (?*) SUFFIX="/${SUFFIX%/*}" ;;
+esac
+
+if [[ -z "$SERVER_PATH" ]]; then
+  scp "$file" "$SERVER:/home/$USER/public_html/dump/"
+  url="https://$SERVER$SUFFIX/~$USER/dump/$name"
 else
-  scp $file $SERVER:$SERVER_PATH/
-  url="https://$SERVER/$name"
+  scp "$file" "$SERVER:$SERVER_PATH/"
+  url="https://$SERVER$SUFFIX/$name"
 fi
 
-echo $url;
+if type xclip &>/dev/null; then
+  echo "$url" && printf "$url" | xclip -i -selection clipboard
+elif type xsel &>/dev/null; then
+  echo "$url" && printf "$url" | xsel -ib
+else
+  printf "%s\n" "$url"
+fi
 
-echo "$url" | xclip -i
+unset config vowel animal colors name file url ANIMALS COLORS VOWELS &>/dev/null

--- a/jellyshot
+++ b/jellyshot
@@ -28,11 +28,11 @@ ANIMALS=(Aardvark Albatross Alligator Alpaca Ant Anteater Antelope Ape Armadillo
 COLORS=(Red Blue Green Cyan Blue Purple Yellow Lime Magenta Green Orange Brown Maroon Black Silver White)
 VOWELS=(Amazing Gigantic Enormous Huge Broad Ridiculous Shallow Silent Soft Fluffy Dusty Miniature Chucklesome Absurd Hilarious Droll Amusing Silly Hysterical Humorous Laughable Astounding Astonishing Stunning Bewildering Shocking Startling Breathtaking Disconcerting Fierce Evil Frightened Foolish Creepy Confused Arrogant Ashamed Angry Awful Cheerful Witty Proud Jolly Kind Gentle)
 
-vowel=$(rand_element "VOWELS[@]")
-color=$(rand_element "COLORS[@]")
-animal=$(rand_element "ANIMALS[@]")
+vowel="$(rand_element "VOWELS[@]")"
+colors="$(rand_element "COLORS[@]")"
+animal="$(rand_element "ANIMALS[@]")"
 
-name="${vowel}${color}${animal}.png"
+name="${vowel}${colors}${animal}.png"
 file="/tmp/$name"
 
 import "$file"

--- a/jellyshot
+++ b/jellyshot
@@ -1,13 +1,25 @@
 #!/bin/bash
 
-# XXX: XDG_CONFIG_HOME
-config="${HOME}/.config/jellyshot/config"
+# Let trap catch non-zero exit status
+set -E -o pipefail
 
-if [[ -f ${config} ]];
-then
-  . "${config}"
+# Traps for cleanup
+trap '{ [[ -f "$file" ]] && rm -v "$file"; }' EXIT
+trap '{ [[ -f "$file" ]] && rm -v "$file"; exit 1; }' ERR
+trap '{ [[ -f "$file" ]] && rm -v "$file"; trap - INT; kill -INT $$; }' INT
+
+function rand_element () {
+  local -a arr
+  arr=("${!1}")
+  echo "${arr["$[RANDOM % ${#arr[@]}]"]}"
+}
+
+config="${XDG_CONFIG_HOME:-${HOME}/.config}/jellyshot/config"
+
+if [[ -f "$config" ]]; then
+  . "$config"
 else
-  echo "No configuration available at ${config}"
+  printf "%s: %s\n" "No configuration available at" "$config"
   exit 1
 fi
 
@@ -15,11 +27,6 @@ ANIMALS=(Aardvark Albatross Alligator Alpaca Ant Anteater Antelope Ape Armadillo
 
 COLORS=(Red Blue Green Cyan Blue Purple Yellow Lime Magenta Green Orange Brown Maroon Black Silver White)
 VOWELS=(Amazing Gigantic Enormous Huge Broad Ridiculous Shallow Silent Soft Fluffy Dusty Miniature Chucklesome Absurd Hilarious Droll Amusing Silly Hysterical Humorous Laughable Astounding Astonishing Stunning Bewildering Shocking Startling Breathtaking Disconcerting Fierce Evil Frightened Foolish Creepy Confused Arrogant Ashamed Angry Awful Cheerful Witty Proud Jolly Kind Gentle)
-
-rand_element() {
-  arr=("${!1}"); 
-  echo ${arr["$[RANDOM % ${#arr[@]}]"]};
-}
 
 vowel=$(rand_element "VOWELS[@]")
 color=$(rand_element "COLORS[@]")
@@ -42,6 +49,5 @@ else
 fi
 
 echo $url;
-rm $file # XXX use TRAP
 
 echo "$url" | xclip -i


### PR DESCRIPTION
- Add **SUFFIX** configuration variable in case the user
	wants something like "/tmp" suffixed to urls; **SUFFIX**
	becomes a noop if not set

- Change `color` variables to `colors`
	(due to namespace conflict with the `color` binary in:
	_extra/graphviz_, _community/pork_,
	and _community/vim-latexsuite_)

- Move rand_element() function definition to top